### PR TITLE
use demo key for google STT

### DIFF
--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -84,6 +84,8 @@ class KeySTT(STT):
 class GoogleSTT(TokenSTT):
     def __init__(self):
         super(GoogleSTT, self).__init__()
+        # allow None to use demo key by default
+        self.token = self.credential.get("token")
 
     def execute(self, audio, language=None):
         self.lang = language or self.lang


### PR DESCRIPTION
googleSTT has been deprecated, no new keys can be obtained

 takes advantage of the demo google key from [speech_recognition](https://github.com/Uberi/speech_recognition/blob/master/speech_recognition/__init__.py#L870) package if None is provided