### PR TITLE
feat/optional backend

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -55,17 +55,22 @@ class Api:
                                     USER_CONFIG],
                                    cache=False)
         config_server = config.get("server")
+        self.disabled = config_server.get("disabled", True)
         self.url = config_server.get("url")
         self.version = config_server.get("version")
         self.identity = IdentityManager.get()
 
     def request(self, params):
+        if self.disabled:
+            return
         self.check_token()
         self.build_path(params)
         self.old_params = copy(params)
         return self.send(params)
 
     def check_token(self):
+        if self.disabled:
+            return
         # If the identity hasn't been loaded, load it
         if not self.identity.has_refresh():
             self.identity = IdentityManager.load()
@@ -77,6 +82,8 @@ class Api:
                 self.refresh_token()
 
     def refresh_token(self):
+        if self.disabled:
+            return
         LOG.debug('Refreshing token')
         if identity_lock.acquire(blocking=False):
             try:
@@ -117,6 +124,8 @@ class Api:
         Returns:
             Requests response object.
         """
+        if self.disabled:
+            return
         query_data = frozenset(params.get('query', {}).items())
         params_key = (params.get('path'), query_data)
         etag = self.params_to_etag.get(params_key)
@@ -159,6 +168,8 @@ class Api:
         Returns:
             data fetched from server
         """
+        if self.disabled:
+            return
         data = self.get_data(response)
 
         if 200 <= response.status_code < 300:
@@ -226,12 +237,16 @@ class DeviceApi(Api):
         super(DeviceApi, self).__init__("device")
 
     def get_code(self, state):
+        if self.disabled:
+            return
         IdentityManager.update()
         return self.request({
             "path": "/code?state=" + state
         })
 
     def activate(self, state, token):
+        if self.disabled:
+            return
         version = VersionManager.get()
         platform = "unknown"
         platform_build = ""
@@ -256,6 +271,8 @@ class DeviceApi(Api):
         })
 
     def update_version(self):
+        if self.disabled:
+            return
         version = VersionManager.get()
         platform = "unknown"
         platform_build = ""
@@ -278,6 +295,8 @@ class DeviceApi(Api):
         })
 
     def send_email(self, title, body, sender):
+        if self.disabled:
+            return
         return self.request({
             "method": "PUT",
             "path": "/" + self.identity.uuid + "/message",
@@ -285,6 +304,8 @@ class DeviceApi(Api):
         })
 
     def report_metric(self, name, data):
+        if self.disabled:
+            return
         return self.request({
             "method": "POST",
             "path": "/" + self.identity.uuid + "/metric/" + name,
@@ -293,6 +314,8 @@ class DeviceApi(Api):
 
     def get(self):
         """ Retrieve all device information from the web backend """
+        if self.disabled:
+            return
         return self.request({
             "path": "/" + self.identity.uuid
         })
@@ -303,6 +326,8 @@ class DeviceApi(Api):
         Returns:
             str: JSON string with user configuration information.
         """
+        if self.disabled:
+            return
         return self.request({
             "path": "/" + self.identity.uuid + "/setting"
         })
@@ -313,6 +338,8 @@ class DeviceApi(Api):
         Returns:
             str: JSON string with user location.
         """
+        if self.disabled:
+            return
         return self.request({
             "path": "/" + self.identity.uuid + "/location"
         })
@@ -324,6 +351,8 @@ class DeviceApi(Api):
 
             Returns: dictionary with subscription information
         """
+        if self.disabled:
+            return
         return self.request({
             'path': '/' + self.identity.uuid + '/subscription'})
 
@@ -333,6 +362,8 @@ class DeviceApi(Api):
             status of subscription. True if device is connected to a paying
             subscriber.
         """
+        if self.disabled:
+            return False
         try:
             return self.get_subscription().get('@type') != 'free'
         except Exception:
@@ -340,6 +371,8 @@ class DeviceApi(Api):
             return False
 
     def get_subscriber_voice_url(self, voice=None):
+        if self.disabled:
+            return
         self.check_token()
         archs = {'x86_64': 'x86_64', 'armv7l': 'arm', 'aarch64': 'arm'}
         arch = archs.get(get_arch())
@@ -357,6 +390,8 @@ class DeviceApi(Api):
             Returns:
                 json string containing token and additional information
         """
+        if self.disabled:
+            return
         return self.request({
             "method": "GET",
             "path": "/" + self.identity.uuid + "/token/" + str(dev_cred)
@@ -412,6 +447,8 @@ class DeviceApi(Api):
         Arguments:
              data: dictionary with skills data from msm
         """
+        if self.disabled:
+            return
         if not isinstance(data, dict):
             raise ValueError('data must be of type dict')
 
@@ -469,12 +506,25 @@ class STTApi(Api):
         })
 
 
+def is_disabled():
+    # Load the config, skipping the REMOTE_CONFIG since we are
+    # getting the info needed to get to it!
+    config = Configuration.get([DEFAULT_CONFIG,
+                                SYSTEM_CONFIG,
+                                USER_CONFIG],
+                               cache=False)
+    config_server = config.get("server")
+    return config_server.get("disabled", False)
+
+
 def has_been_paired():
     """ Determine if this device has ever been paired with a web backend
 
     Returns:
         bool: True if ever paired with backend (not factory reset)
     """
+    if is_disabled():
+        return True
     # This forces a load from the identity file in case the pairing state
     # has recently changed
     id = IdentityManager.load()
@@ -490,6 +540,8 @@ def is_paired(ignore_errors=True):
     Returns:
         bool: True if paired with backend
     """
+    if is_disabled():
+        return True
     global _paired_cache
     if _paired_cache:
         # NOTE: This assumes once paired, the unit remains paired.  So

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -136,8 +136,8 @@ class RemoteConf(LocalConf):
         super(RemoteConf, self).__init__(None)
 
         cache = cache or WEB_CONFIG_CACHE
-        from mycroft.api import is_paired
-        if not is_paired():
+        from mycroft.api import is_paired, is_disabled
+        if not is_paired() or is_disabled():
             self.load_local(cache)
             return
 
@@ -145,7 +145,7 @@ class RemoteConf(LocalConf):
             # Here to avoid cyclic import
             from mycroft.api import DeviceApi
             api = DeviceApi()
-            setting = api.get_settings()
+            setting = api.get_settings() or {}
 
             try:
                 location = api.get_location()

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -126,7 +126,8 @@
     "url": "https://api.mycroft.ai",
     "version": "v1",
     "update": true,
-    "metrics": false
+    "metrics": false,
+    "disabled": false
   },
 
   // The mycroft-core messagebus websocket

--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -18,7 +18,7 @@ import time
 
 import requests
 
-from mycroft.api import DeviceApi, is_paired
+from mycroft.api import DeviceApi, is_paired, is_disabled
 from mycroft.configuration import Configuration
 from mycroft.session import SessionManager
 from mycroft.util.log import LOG
@@ -34,6 +34,8 @@ def report_metric(name, data):
         name (str): Name of metric. Must use only letters and hyphens
         data (dict): JSON dictionary to report. Must be valid JSON
     """
+    if is_disabled():
+        return
     try:
         if is_paired() and Configuration().get()['opt_in']:
             DeviceApi().report_metric(name, data)
@@ -172,6 +174,8 @@ class MetricsPublisher:
         conf = Configuration().get()['server']
         self.url = url or conf['url']
         self.enabled = enabled or conf['metrics']
+        if conf.get("disabled", True):
+            self.enabled = False
 
     def publish(self, events):
         if 'session_id' not in events:

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -71,7 +71,7 @@ from os.path import isfile, join, expanduser
 from requests.exceptions import RequestException, HTTPError
 from msm import SkillEntry
 
-from mycroft.api import DeviceApi, is_paired
+from mycroft.api import DeviceApi, is_paired, is_disabled
 from mycroft.util.log import LOG
 from mycroft.util import camel_case_split
 from mycroft.configuration import ConfigurationManager
@@ -206,6 +206,8 @@ class SkillSettings(dict):
     # TODO: break this up into two classes
     def initialize_remote_settings(self):
         """ initializes the remote settings to the server """
+        if is_disabled():
+            return
         # if the settingsmeta file exists (and is valid)
         # this block of code is a control flow for
         # different scenarios that may arises with settingsmeta
@@ -294,6 +296,8 @@ class SkillSettings(dict):
         Returns:
             dict: uuid, a unique id for the setting meta data
         """
+        if is_disabled():
+            return None
         if self._meta_upload:
             try:
                 uuid = self.api.upload_skill_metadata(
@@ -351,6 +355,8 @@ class SkillSettings(dict):
             settings_meta (dict): settingsmeta.json or settingsmeta.yaml
             identifier (str): identifier for skills meta data
         """
+        if is_disabled():
+            return
         LOG.debug('Uploading settings meta for {}'.format(identifier))
         meta = self._migrate_settings(settings_meta)
         meta['identifier'] = identifier
@@ -362,6 +368,8 @@ class SkillSettings(dict):
 
     def update_remote(self):
         """ update settings state from server """
+        if is_disabled():
+            return
         settings_meta = self._load_settings_meta()
         if settings_meta is None:
             return
@@ -399,6 +407,8 @@ class SkillSettings(dict):
             request settings and store it if it changes
             TODO: implement as websocket
         """
+        if is_disabled():
+            return
         delay = 1
         original = hash(str(self))
         try:
@@ -507,6 +517,8 @@ class SkillSettings(dict):
         Returns:
             skill_settings (dict or None): returns a dict if matches
         """
+        if is_disabled():
+            return None
         settings = self._request_settings()
         if settings:
             # this loads the settings into memory for use in self.store
@@ -525,6 +537,8 @@ class SkillSettings(dict):
         Returns:
             dict: dictionary with settings collected from the server.
         """
+        if is_disabled():
+            return None
         try:
             settings = self.api.get_skill_settings()
         except RequestException:
@@ -535,6 +549,8 @@ class SkillSettings(dict):
 
     @property
     def _should_upload_from_change(self):
+        if is_disabled():
+            return False
         changed = False
         if (hasattr(self, '_remote_settings') and
                 'skillMetadata' in self._remote_settings):


### PR DESCRIPTION
## Description

You can disable backend globally by setting "disabled" to True

```json
  "server": {
    "url": "http://0.0.0.0:6712",
    "version": "v0.1",
    "update": false,
    "metrics": false,
    "disabled": true
  }
```

utility method

```python
from mycroft.api import is_disabled

if not is_disabled():
    print("404 privacy not found")
```

