### PR TITLE
feat/converse timeout event

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -598,6 +598,7 @@ class MycroftSkill:
                            self.handle_set_cross_context)
             self.add_event("mycroft.skill.remove_cross_context",
                            self.handle_remove_cross_context)
+            self.add_event("converse.timeout", self._deactivate_skill)
             name = 'mycroft.skills.settings.update'
             func = self.settings.run_poll
             bus.on(name, func)
@@ -629,7 +630,18 @@ class MycroftSkill:
         """
         return None
 
-    def converse(self, utterances, lang=None):
+    def _deactivate_skill(self, message):
+        skill_id = message.data.get("skill_id")
+        if skill_id == self.skill_id:
+            self.on_converse_timeout()
+
+    def on_converse_timeout(self):
+        """
+        Invoked when the skill is removed from active skill list
+        """
+        pass
+
+    def converse(self, utterances, lang="en-us"):
         """ Handle conversation.
 
         This method gets a peek at utterances before the normal intent

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -397,9 +397,11 @@ class IntentService:
         """
 
         # check for conversation time-out
-        self.active_skills = [skill for skill in self.active_skills
-                              if time.time() - skill[
-                                  1] <= self.converse_timeout * 60]
+        for skill in list(self.active_skills):
+            if time.time() - skill[1] <= self.converse_timeout * 60:
+                self.bus.emit(Message("converse.timeout",
+                                      {"skill_id": skill[0]}))
+                self.active_skills.remove(skill)
 
         # check if any skill wants to handle utterance
         for skill in self.active_skills:


### PR DESCRIPTION
Same as https://github.com/MycroftAI/mycroft-core/pull/1468

adds a callback for when a skill is removed from active skills list

allows for example a skill to keep itself always active, or reset states if it was expecting to use converse method but didn't