### PR TITLE
Feat/flexible lang dir

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1426,12 +1426,12 @@ class MycroftSkill:
     def init_dialog(self, root_directory):
         # If "<skill>/dialog/<lang>" exists, load from there.  Otherwise
         # load dialog from "<skill>/locale/<lang>"
-        dialog_dir = join(root_directory, 'dialog', self.lang)
+        dialog_dir = get_language_dir(join(root_directory, 'dialog'), self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
         if exists(dialog_dir):
             self.dialog_renderer = DialogLoader().load(dialog_dir)
-        elif exists(join(root_directory, 'locale', self.lang)):
-            locale_path = join(root_directory, 'locale', self.lang)
-            self.dialog_renderer = DialogLoader().load(locale_path)
+        elif exists(locale_dir):
+            self.dialog_renderer = DialogLoader().load(locale_dir)
         else:
             LOG.debug('No dialog loaded')
 
@@ -1442,22 +1442,22 @@ class MycroftSkill:
         self.load_regex_files(root_directory)
 
     def load_vocab_files(self, root_directory):
-        vocab_dir = join(root_directory, 'vocab', self.lang)
+        vocab_dir = get_language_dir(join(root_directory, 'vocab'), self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
         if exists(vocab_dir):
             load_vocabulary(vocab_dir, self.bus, self.skill_id)
-        elif exists(join(root_directory, 'locale', self.lang)):
-            load_vocabulary(join(root_directory, 'locale', self.lang),
-                            self.bus, self.skill_id)
+        elif exists(locale_dir):
+            load_vocabulary(locale_dir, self.bus, self.skill_id)
         else:
             LOG.debug('No vocab loaded')
 
     def load_regex_files(self, root_directory):
-        regex_dir = join(root_directory, 'regex', self.lang)
+        regex_dir = get_language_dir(join(root_directory, 'regex'), self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
         if exists(regex_dir):
             load_regex(regex_dir, self.bus, self.skill_id)
-        elif exists(join(root_directory, 'locale', self.lang)):
-            load_regex(join(root_directory, 'locale', self.lang),
-                       self.bus, self.skill_id)
+        elif exists(locale_dir):
+            load_regex(locale_dir, self.bus, self.skill_id)
 
     def __handle_stop(self, event):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1426,8 +1426,10 @@ class MycroftSkill:
     def init_dialog(self, root_directory):
         # If "<skill>/dialog/<lang>" exists, load from there.  Otherwise
         # load dialog from "<skill>/locale/<lang>"
-        dialog_dir = get_language_dir(join(root_directory, 'dialog'), self.lang)
-        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
+        dialog_dir = get_language_dir(join(root_directory, 'dialog'),
+                                      self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'),
+                                      self.lang)
         if exists(dialog_dir):
             self.dialog_renderer = DialogLoader().load(dialog_dir)
         elif exists(locale_dir):
@@ -1442,8 +1444,10 @@ class MycroftSkill:
         self.load_regex_files(root_directory)
 
     def load_vocab_files(self, root_directory):
-        vocab_dir = get_language_dir(join(root_directory, 'vocab'), self.lang)
-        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
+        vocab_dir = get_language_dir(join(root_directory, 'vocab'),
+                                     self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'),
+                                      self.lang)
         if exists(vocab_dir):
             load_vocabulary(vocab_dir, self.bus, self.skill_id)
         elif exists(locale_dir):
@@ -1452,8 +1456,10 @@ class MycroftSkill:
             LOG.debug('No vocab loaded')
 
     def load_regex_files(self, root_directory):
-        regex_dir = get_language_dir(join(root_directory, 'regex'), self.lang)
-        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
+        regex_dir = get_language_dir(join(root_directory, 'regex'),
+                                     self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'),
+                                      self.lang)
         if exists(regex_dir):
             load_regex(regex_dir, self.bus, self.skill_id)
         elif exists(locale_dir):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -46,7 +46,8 @@ from mycroft.skills.skill_data import (load_vocabulary, load_regex, to_alnum,
                                        read_vocab_file)
 from mycroft.util import (camel_case_split,
                           resolve_resource_file,
-                          play_audio_file)
+                          play_audio_file,
+                          get_language_dir)
 from mycroft.util.log import LOG
 
 MainModule = '__init__'
@@ -936,8 +937,10 @@ class MycroftSkill:
             string: The full path to the resource file or None if not found
         """
         if res_dirname:
+            root_path = get_language_dir(join(self.root_dir, res_dirname),
+                                         self.lang)
             # Try the old translated directory (dialog/vocab/regex)
-            path = join(self.root_dir, res_dirname, self.lang, res_name)
+            path = join(root_path, res_name)
             if exists(path):
                 return path
 
@@ -947,7 +950,7 @@ class MycroftSkill:
                 return path
 
         # New scheme:  search for res_name under the 'locale' folder
-        root_path = join(self.root_dir, 'locale', self.lang)
+        root_path = get_language_dir(join(self.root_dir, 'locale'), self.lang)
         for path, _, files in os.walk(root_path):
             if res_name in files:
                 return join(path, res_name)

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -524,7 +524,7 @@ def camel_case_split(identifier: str) -> str:
 
 
 def get_language_dir(base_path, lang="en-us"):
-    # checks for all language variations and returns best path
+    """ checks for all language variations and returns best path """
     lang_path = os.path.join(base_path, lang)
     # base_path/en-us
     if os.path.isdir(lang_path):
@@ -539,8 +539,7 @@ def get_language_dir(base_path, lang="en-us"):
         main = lang
     # base_path/en-uk, base_path/en-au...
     if os.path.isdir(base_path):
-        candidates = [f for f in os.listdir(base_path) if f.startswith(main)]
-        candidates = [os.path.join(base_path, c) for c in candidates]
+        candidates = [os.path.join(base_path, f) for f in os.listdir(base_path) if f.startswith(main)]
         paths = [p for p in candidates if os.path.isdir(p)]
         # TODO how to choose best local dialect?
         if len(paths):

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -539,7 +539,8 @@ def get_language_dir(base_path, lang="en-us"):
         main = lang
     # base_path/en-uk, base_path/en-au...
     if os.path.isdir(base_path):
-        candidates = [os.path.join(base_path, f) for f in os.listdir(base_path) if f.startswith(main)]
+        candidates = [os.path.join(base_path, f)
+                      for f in os.listdir(base_path) if f.startswith(main)]
         paths = [p for p in candidates if os.path.isdir(p)]
         # TODO how to choose best local dialect?
         if len(paths):

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -521,3 +521,28 @@ def camel_case_split(identifier: str) -> str:
     regex = '.+?(?:(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|$)'
     matches = re.finditer(regex, identifier)
     return ' '.join([m.group(0) for m in matches])
+
+
+def get_language_dir(base_path, lang="en-us"):
+    # checks for all language variations and returns best path
+    lang_path = os.path.join(base_path, lang)
+    # base_path/en-us
+    if os.path.isdir(lang_path):
+        return lang_path
+    if "-" in lang:
+        main = lang.split("-")[0]
+        # base_path/en
+        general_lang_path = os.path.join(base_path, main)
+        if os.path.isdir(general_lang_path):
+            return general_lang_path
+    else:
+        main = lang
+    # base_path/en-uk, base_path/en-au...
+    if os.path.isdir(base_path):
+        candidates = [f for f in os.listdir(base_path) if f.startswith(main)]
+        candidates = [os.path.join(base_path, c) for c in candidates]
+        paths = [p for p in candidates if os.path.isdir(p)]
+        # TODO how to choose best local dialect?
+        if len(paths):
+            return paths[0]
+    return os.path.join(base_path, lang)


### PR DESCRIPTION
support language code variations, adds a utility function and implements it in skills core where relevant

check for language code variations, lets say we want to access "path/en-uk" , but it does not exist, this PR adds methods to check for "path/en" , "path/en-us" etc, and returns the best language alternative

skills in "en-us" will still work if i configure mycroft for "en-uk", or "es-es" skills will work if i configure mycroft lang for "es"