### PR TITLE
Feat/fallback order override

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1810,11 +1810,22 @@ class FallbackSkill(MycroftSkill):
         self.instance_fallback_handlers.append(wrapper)
 
         if self.override:
+            #  ========   ========   =======================================
+            #  Priority   Who?       Purpose
+            #  ========   ========   =======================================
+            #     1       RESERVED   Slot for pre-Padatious if needed
+            #     5       MYCROFT    Padatious near match (conf > 0.8)
+            #     6       USER       General
+            #     89      MYCROFT    Padatious loose match (conf > 0.5)
+            #     90      USER       Uncaught intents
+            #     100     MYCROFT    Fallback Unknown or other future use
+            #  ========   ========   =======================================
+
             folder = self.root_dir.split("/")[-1]
             if folder in self.fallback_order:
-                priority = self.fallback_order.index(folder) + 1
+                priority = self.fallback_order.index(folder) + 5
             else:
-                priority = 100
+                priority = 88
 
         self._register_fallback(wrapper, priority)
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1729,7 +1729,7 @@ class FallbackSkill(MycroftSkill):
     """
     fallback_handlers = {}
     skills_config = Configuration.get().get("skills", {})
-    override_order = skills_config.get("override", False)
+    override = skills_config.get("override", False)
     fallback_order = skills_config.get("fallback_order", [])
 
     def __init__(self, name=None, bus=None, use_settings=True):
@@ -1809,7 +1809,7 @@ class FallbackSkill(MycroftSkill):
 
         self.instance_fallback_handlers.append(wrapper)
 
-        if self.override_order:
+        if self.override:
             folder = self.root_dir.split("/")[-1]
             if folder in self.fallback_order:
                 priority = self.fallback_order.index(folder) + 1

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1728,6 +1728,9 @@ class FallbackSkill(MycroftSkill):
         utterance will not be see by any other Fallback handlers.
     """
     fallback_handlers = {}
+    skills_config = Configuration.get().get("skills", {})
+    override_order = skills_config.get("override", False)
+    fallback_order = skills_config.get("fallback_order", [])
 
     def __init__(self, name=None, bus=None, use_settings=True):
         MycroftSkill.__init__(self, name, bus, use_settings)
@@ -1805,6 +1808,14 @@ class FallbackSkill(MycroftSkill):
             return False
 
         self.instance_fallback_handlers.append(wrapper)
+
+        if self.override_order:
+            folder = self.root_dir.split("/")[-1]
+            if folder in self.fallback_order:
+                priority = self.fallback_order.index(folder) + 1
+            else:
+                priority = 100
+
         self._register_fallback(wrapper, priority)
 
     @classmethod

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1822,10 +1822,15 @@ class FallbackSkill(MycroftSkill):
             #  ========   ========   =======================================
 
             folder = self.root_dir.split("/")[-1]
-            if folder in self.fallback_order:
-                priority = self.fallback_order.index(folder) + 5
+            if folder == "padatious_service":
+                # do not override padatious intents
+                pass
+            elif folder in self.fallback_order:
+                # assign new priority
+                priority = self.fallback_order.index(folder) + 6
             else:
-                priority = 88
+                # offset priority to keep order of non overrided fallbacks
+                priority += len(self.fallback_order) + 6
 
         self._register_fallback(wrapper, priority)
 

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -17,7 +17,7 @@ from subprocess import call
 from threading import Event
 from time import time as get_time, sleep
 
-from os.path import expanduser, isfile
+from os.path import expanduser, isfile, dirname
 from pkg_resources import get_distribution
 
 from mycroft.configuration import Configuration
@@ -61,6 +61,7 @@ class PadatiousService(FallbackSkill):
         self.bus.on('detach_skill', self.handle_detach_skill)
         self.bus.on('mycroft.skills.initialized', self.train)
 
+        self.root_dir = dirname(__file__)  # for override
         # Call Padatious an an early fallback, looking for a high match intent
         self.register_fallback(self.handle_fallback,
                                PadatiousService.fallback_tight_match)


### PR DESCRIPTION
sometimes we may not agree with dev choices on fallback priority, provides an option to override the fallback order in config 

```json5
{
    "skills": {
          "override": true,
          "fallback_order": ["padatious", "skill_folder_name1", ... ,  "skill_folder_nameN" ]
     }
}
```